### PR TITLE
package.json の license を明記する

### DIFF
--- a/section_report/package.json
+++ b/section_report/package.json
@@ -2,6 +2,7 @@
   "name": "thinreports-editor",
   "version": "1.0.0-sectionreport.1",
   "private": true,
+  "license": "SEE LICENSE IN LICENSE FILE",
   "scripts": {
     "serve": "cross-env VUE_APP_HANDLERS=browser vue-cli-service serve",
     "build": "cross-env VUE_APP_HANDLERS=browser vue-cli-service build",


### PR DESCRIPTION
`section_report/` のライセンスは当然オリジナルのライセンスに従う。

下記の記述方法を参考に、トップレベルの `LICENSE` に従う旨を明記する。
https://docs.npmjs.com/files/package.json#license

> Then include a file named <filename> at the top level of the package.

とあるため、単に `LICENSE` としても良いが、前半の `SEE LICENSE` と混在してわかりづらくなるため、`LICENSE FILE` としている。